### PR TITLE
fix: change wezterm default protocol

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,6 @@ fn main() {
     let options = options::Options::parse();
 
     if let Err(err) = previewer::preview(&mut stdout, &options) {
-        eprintln!("{err}")
+        eprintln!("{err}");
     };
 }

--- a/src/previewer/sixel.rs
+++ b/src/previewer/sixel.rs
@@ -17,12 +17,12 @@ pub fn display(stdout: &mut impl Write, options: &Options) -> Result {
     };
 
     let encoder = Encoder::new()?;
-    encoder.set_width(Pixel((cols * col_size) as u64))?;
-    encoder.set_height(Pixel((rows * row_size) as u64))?;
+    encoder.set_width(Pixel(u64::from(cols * col_size)))?;
+    encoder.set_height(Pixel(u64::from(rows * row_size)))?;
     encoder.set_resampling(ResampleMethod::Nearest)?;
     encoder.set_encode_policy(EncodePolicy::Fast)?;
     if options.gif_static {
-        encoder.use_static()?
+        encoder.use_static()?;
     };
 
     move_cursor(stdout, options.x, options.y)?;

--- a/src/support.rs
+++ b/src/support.rs
@@ -30,10 +30,10 @@ impl Protocol {
     pub fn choose(options: &Options) -> Self {
         if let Some(protocol) = options.protocol {
             protocol
-        } else if Protocol::support_kitty() {
-            Protocol::Kitty
         } else if Protocol::support_iterm() {
             Protocol::Iterm
+        } else if Protocol::support_kitty() {
+            Protocol::Kitty
         } else if Protocol::support_sixel() {
             Protocol::Sixel
         } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,10 +52,10 @@ pub struct TermSize {
 impl TermSize {
     pub fn new(rows: u16, cols: u16, width: u16, height: u16) -> Self {
         Self {
-            rows: rows as u32,
-            cols: cols as u32,
-            width: width as u32,
-            height: height as u32,
+            rows: u32::from(rows),
+            cols: u32::from(cols),
+            width: u32::from(width),
+            height: u32::from(height),
         }
     }
 
@@ -236,23 +236,26 @@ pub fn pixel_is_transparent(rgb: [u8; 4]) -> bool {
 }
 
 pub fn ansi_rgb(rgb: [u8; 4], bg: bool) -> String {
-    match bg {
-        false => format!("\x1b[38;2;{};{};{}m", rgb[0], rgb[1], rgb[2]),
-        true => format!("\x1b[48;2;{};{};{}m", rgb[0], rgb[1], rgb[2]),
+    if bg {
+        format!("\x1b[48;2;{};{};{}m", rgb[0], rgb[1], rgb[2])
+    } else {
+        format!("\x1b[38;2;{};{};{}m", rgb[0], rgb[1], rgb[2])
     }
 }
 
 pub fn ansi_indexed(rgb: [u8; 4], bg: bool) -> String {
     let index = ansi256_from_rgb((rgb[0], rgb[1], rgb[2]));
-    match bg {
-        false => format!("\x1b[38;5;{}m", index),
-        true => format!("\x1b[48;5;{}m", index),
+    if bg {
+        format!("\x1b[48;5;{index}m")
+    } else {
+        format!("\x1b[38;5;{index}m")
     }
 }
 
 pub fn ansi_color(rgb: [u8; 4], bg: bool) -> String {
-    match support::truecolor() {
-        true => ansi_rgb(rgb, bg),
-        false => ansi_indexed(rgb, bg),
+    if support::truecolor() {
+        ansi_rgb(rgb, bg)
+    } else {
+        ansi_indexed(rgb, bg)
     }
 }


### PR DESCRIPTION
Tested both kitty and iTerm protocols on Wezterm and found that iTerm has better resolution and is faster than kitty. Changed order of support checking so it uses iTerm by default.