### PR TITLE
Feature/multiple preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "half"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +565,7 @@ dependencies = [
  "libc",
  "sixel-rs",
  "tempfile",
+ "wild",
 ]
 
 [[package]]
@@ -877,6 +884,15 @@ name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "wild"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b116685a6be0c52f5a103334cbff26db643826c7b3735fc0a3ba9871310a74"
+dependencies = [
+ "glob",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 ansi_colours = { version = "1.2.1", default-features = false }
 base64 = "0.21.0"
 clap = { version = "4.1.1", features = ["derive"] }
+wild = "2.1.0"
 console = { version = "0.15.5", default-features = false }
 crossbeam-channel = "0.5.6"
 ctrlc = "3.2.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,9 @@ mod utils;
 
 fn main() {
     let mut stdout = std::io::stdout();
-    let options = options::Options::parse_from(wild::args());
+    let mut options = options::Options::parse_from(wild::args());
 
-    if let Err(err) = previewer::preview(&mut stdout, &options) {
+    if let Err(err) = previewer::preview(&mut stdout, &mut options) {
         eprintln!("{err}");
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod utils;
 
 fn main() {
     let mut stdout = std::io::stdout();
-    let options = options::Options::parse();
+    let options = options::Options::parse_from(wild::args());
 
     if let Err(err) = previewer::preview(&mut stdout, &options) {
         eprintln!("{err}");

--- a/src/options.rs
+++ b/src/options.rs
@@ -24,6 +24,9 @@ pub struct Options {
     /// Number of rows to fit the preview in
     #[arg(short, long)]
     pub rows: Option<u32>,
+    /// Spacing between images if more than one file is provided
+    #[arg(long)]
+    pub spacing: Option<u32>,
     /// Upscale image if needed
     #[arg(short, long)]
     pub upscale: bool,

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,13 +1,17 @@
 use crate::support::Protocol;
-use clap::Parser;
+use clap::{arg, command, Parser};
 use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(author, version, about)]
 pub struct Options {
-    /// Image to preview
-    pub path: PathBuf,
+    /// Image(s) to preview
+    #[arg(num_args(1..))]
+    pub path: Vec<PathBuf>,
 
+    /// Previewing protocol to use
+    #[arg(short, long)]
+    pub protocol: Option<Protocol>,
     /// x position (0 is left)
     #[arg(short, long)]
     pub x: Option<u32>,
@@ -24,14 +28,12 @@ pub struct Options {
     #[arg(short, long)]
     pub upscale: bool,
     /// Only show first frame of GIFs
-    #[arg(short = 's', long = "static")]
+    #[arg(short = 's', long = "static", conflicts_with("gif_loop"))]
     pub gif_static: bool,
     /// Loop GIFs infinitely
     #[arg(short = 'l', long = "loop")]
     pub gif_loop: bool,
-    /// Previewing protocol to use
-    #[arg(short, long)]
-    pub protocol: Option<Protocol>,
+
     /// Load image with the given id (kitty only)
     #[arg(long, value_name = "ID")]
     pub load: Option<u32>,

--- a/src/previewer/blocks.rs
+++ b/src/previewer/blocks.rs
@@ -9,6 +9,7 @@ use image::codecs::gif::GifDecoder;
 use image::{AnimationDecoder, DynamicImage, ImageFormat};
 use std::fs::File;
 use std::io::{Read, Write};
+use std::path::PathBuf;
 // use std::thread;
 use std::time::Duration;
 
@@ -108,7 +109,7 @@ fn display_gif(stdout: &mut impl Write, buffer: &[u8], options: &Options) -> Res
         let mut first_frame = true;
 
         'gif: loop {
-            for (delay, frame) in frames.iter() {
+            for (delay, frame) in &frames {
                 select! {
                     default(*delay) => {
                         if first_frame {
@@ -136,8 +137,8 @@ fn display_gif(stdout: &mut impl Write, buffer: &[u8], options: &Options) -> Res
     }
 }
 
-pub fn preview(stdout: &mut impl Write, options: &Options) -> Result {
-    let mut image = File::open(&options.path)?;
+pub fn preview(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> Result {
+    let mut image = File::open(image_path)?;
     let mut buffer = Vec::new();
     image.read_to_end(&mut buffer)?;
 

--- a/src/previewer/blocks.rs
+++ b/src/previewer/blocks.rs
@@ -1,8 +1,8 @@
 use crate::options::Options;
 use crate::result::Result;
 use crate::utils::{
-    ansi_color, fit_in_bounds, hide_cursor, move_cursor, move_cursor_up, pixel_is_transparent,
-    resize, show_cursor, CtrlcHandler, TermSize,
+    ansi_color, fit_in_bounds, handle_spacing, hide_cursor, move_cursor, move_cursor_up,
+    pixel_is_transparent, resize, show_cursor, CtrlcHandler, TermSize,
 };
 use crossbeam_channel::select;
 use image::codecs::gif::GifDecoder;
@@ -143,7 +143,10 @@ pub fn preview(stdout: &mut impl Write, image_path: &PathBuf, options: &Options)
     image.read_to_end(&mut buffer)?;
 
     match image::guess_format(&buffer)? {
-        ImageFormat::Gif => display_gif(stdout, &buffer, options),
-        _ => display_image(stdout, &buffer, options),
+        ImageFormat::Gif => display_gif(stdout, &buffer, options)?,
+        _ => display_image(stdout, &buffer, options)?,
     }
+
+    handle_spacing(stdout, options.spacing)?;
+    Ok(())
 }

--- a/src/previewer/iterm.rs
+++ b/src/previewer/iterm.rs
@@ -5,13 +5,14 @@ use base64::{engine::general_purpose, Engine as _};
 use image::ImageFormat;
 use std::fs::File;
 use std::io::{Read, Write};
+use std::path::PathBuf;
 
-fn display(stdout: &mut impl Write, options: &Options) -> Result {
-    let mut image = File::open(&options.path)?;
+fn display(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> Result {
+    let mut image = File::open(image_path)?;
     let mut buffer = Vec::new();
     image.read_to_end(&mut buffer)?;
 
-    let image_size = imagesize::size(&options.path)?;
+    let image_size = imagesize::size(image_path)?;
     let (width, height) = (image_size.width as u32, image_size.height as u32);
     let (cols, rows) = fit_in_bounds(width, height, options.cols, options.rows, options.upscale)?;
 
@@ -32,6 +33,6 @@ fn display(stdout: &mut impl Write, options: &Options) -> Result {
     Ok(())
 }
 
-pub fn preview(stdout: &mut impl Write, options: &Options) -> Result {
-    display(stdout, options)
+pub fn preview(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> Result {
+    display(stdout, image_path, options)
 }

--- a/src/previewer/iterm.rs
+++ b/src/previewer/iterm.rs
@@ -1,13 +1,13 @@
 use crate::options::Options;
 use crate::result::Result;
-use crate::utils::{convert_to_image_buffer, fit_in_bounds, move_cursor};
+use crate::utils::{convert_to_image_buffer, fit_in_bounds, handle_spacing, move_cursor};
 use base64::{engine::general_purpose, Engine as _};
 use image::ImageFormat;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-fn display(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> Result {
+fn display(stdout: &mut impl Write, image_path: &PathBuf, options: &mut Options) -> Result {
     let mut image = File::open(image_path)?;
     let mut buffer = Vec::new();
     image.read_to_end(&mut buffer)?;
@@ -24,7 +24,7 @@ fn display(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> 
         _ => general_purpose::STANDARD.encode(buffer),
     };
 
-    let command = format!("\x1b]1337;File=width={cols};height={rows};inline=1;:{data}\x07\n");
+    let command = format!("\x1b]1337;File=width={cols};height={rows};inline=1;:{data}\x07\r");
 
     move_cursor(stdout, options.x, options.y)?;
     stdout.write_all(command.as_bytes())?;
@@ -33,6 +33,8 @@ fn display(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> 
     Ok(())
 }
 
-pub fn preview(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> Result {
-    display(stdout, image_path, options)
+pub fn preview(stdout: &mut impl Write, image_path: &PathBuf, options: &mut Options) -> Result {
+    display(stdout, image_path, options)?;
+    handle_spacing(stdout, options.spacing)?;
+    Ok(())
 }

--- a/src/previewer/kitty.rs
+++ b/src/previewer/kitty.rs
@@ -17,6 +17,7 @@ fn send_graphics_command(stdout: &mut impl Write, command: &str, payload: Option
     let command = format!("{PROTOCOL_START}{command};{data}{PROTOCOL_END}");
 
     stdout.write_all(command.as_bytes())?;
+    stdout.write_all(b"\n")?;
 
     stdout.flush()?;
     Ok(())
@@ -67,16 +68,14 @@ fn display(
         let (cols, rows) =
             fit_in_bounds(width, height, options.cols, options.rows, options.upscale)?;
         save_in_tmp_file(image.as_raw(), &mut tempfile)?;
-        drop(tempfile);
 
-        let command = format!("a=T,t=t,f=32,s={width},v={height},c={cols},r={rows},q=2",);
+        let command = format!("a=T,I=31,t=t,f=32,s={width},v={height},c={cols},r={rows},q=2",);
         (command, pathbuf.to_str())
     };
 
     move_cursor(stdout, options.x, options.y)?;
     send_graphics_command(stdout, &command, payload)?;
 
-    stdout.flush()?;
     Ok(())
 }
 

--- a/src/previewer/kitty.rs
+++ b/src/previewer/kitty.rs
@@ -69,7 +69,7 @@ fn display(
             fit_in_bounds(width, height, options.cols, options.rows, options.upscale)?;
         save_in_tmp_file(image.as_raw(), &mut tempfile)?;
 
-        let command = format!("a=T,I=31,t=t,f=32,s={width},v={height},c={cols},r={rows},q=2",);
+        let command = format!("a=T,t=t,I=13,f=32,s={width},v={height},c={cols},r={rows},q=2",);
         (command, pathbuf.to_str())
     };
 

--- a/src/previewer/kitty.rs
+++ b/src/previewer/kitty.rs
@@ -4,6 +4,7 @@ use crate::utils::{create_temp_file, fit_in_bounds, move_cursor, save_in_tmp_fil
 use base64::{engine::general_purpose, Engine as _};
 use image::io::Reader;
 use std::io::Write;
+use std::path::PathBuf;
 
 const KITTY_PREFIX: &str = "pic.tty-graphics-protocol.";
 const PROTOCOL_START: &str = "\x1b_G";
@@ -27,8 +28,8 @@ fn clear(stdout: &mut impl Write, id: u32, _options: &Options) -> Result {
     }
 }
 
-fn load(stdout: &mut impl Write, id: u32, options: &Options) -> Result {
-    let image = Reader::open(&options.path)?
+fn load(stdout: &mut impl Write, id: u32, image_path: &PathBuf, _options: &Options) -> Result {
+    let image = Reader::open(image_path)?
         .with_guessed_format()?
         .decode()?
         .to_rgba8();
@@ -40,10 +41,15 @@ fn load(stdout: &mut impl Write, id: u32, options: &Options) -> Result {
     send_graphics_command(stdout, &command, pathbuf.to_str())
 }
 
-fn display(stdout: &mut impl Write, id: Option<u32>, options: &Options) -> Result {
+fn display(
+    stdout: &mut impl Write,
+    id: Option<u32>,
+    image_path: &PathBuf,
+    options: &Options,
+) -> Result {
     let (mut tempfile, pathbuf) = create_temp_file(KITTY_PREFIX)?;
     let (command, payload) = if let Some(id) = id {
-        let image_size = imagesize::size(&options.path)?;
+        let image_size = imagesize::size(image_path)?;
         let (width, height) = (image_size.width as u32, image_size.height as u32);
         let (cols, rows) =
             fit_in_bounds(width, height, options.cols, options.rows, options.upscale)?;
@@ -51,7 +57,7 @@ fn display(stdout: &mut impl Write, id: Option<u32>, options: &Options) -> Resul
         let command = format!("a=p,c={cols},r={rows},i={id},q=2");
         (command, None)
     } else {
-        let image = Reader::open(&options.path)?
+        let image = Reader::open(image_path)?
             .with_guessed_format()?
             .decode()?
             .to_rgba8();
@@ -73,18 +79,18 @@ fn display(stdout: &mut impl Write, id: Option<u32>, options: &Options) -> Resul
     Ok(())
 }
 
-pub fn preview(stdout: &mut impl Write, options: &Options) -> Result {
+pub fn preview(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> Result {
     if let Some(id) = options.clear {
         clear(stdout, id, options)?;
     }
 
     match (options.load, options.display) {
         (Some(id_load), Some(id_display)) => {
-            load(stdout, id_load, options)?;
-            display(stdout, Some(id_display), options)
+            load(stdout, id_load, image_path, options)?;
+            display(stdout, Some(id_display), image_path, options)
         }
-        (Some(id), None) => load(stdout, id, options),
-        (None, Some(id)) => display(stdout, Some(id), options),
-        (None, None) => display(stdout, None, options),
+        (Some(id), None) => load(stdout, id, image_path, options),
+        (None, Some(id)) => display(stdout, Some(id), image_path, options),
+        (None, None) => display(stdout, None, image_path, options),
     }
 }

--- a/src/previewer/mod.rs
+++ b/src/previewer/mod.rs
@@ -8,9 +8,17 @@ mod iterm;
 mod kitty;
 mod sixel;
 
-pub fn preview(stdout: &mut impl Write, options: &Options) -> Result {
+pub fn preview(stdout: &mut impl Write, options: &mut Options) -> Result {
     let protocol = Protocol::choose(options);
-    for image_path in &options.path {
+    let image_paths = options.path.clone();
+    // If there is more than one path, render `-y` flag useless
+    // TODO: Does not work if the only path is a directory
+    if options.y.is_some() && image_paths.len() > 1 {
+        options.y = None;
+        // Notify about spacing flag
+    }
+
+    for image_path in &image_paths {
         if image_path.is_dir() {
             continue;
         }

--- a/src/previewer/mod.rs
+++ b/src/previewer/mod.rs
@@ -9,10 +9,13 @@ mod kitty;
 mod sixel;
 
 pub fn preview(stdout: &mut impl Write, options: &Options) -> Result {
-    match Protocol::choose(options) {
-        Protocol::Kitty => kitty::preview(stdout, options),
-        Protocol::Iterm => iterm::preview(stdout, options),
-        Protocol::Sixel => sixel::preview(stdout, options),
-        Protocol::Blocks => blocks::preview(stdout, options),
+    for image_path in &options.path {
+        match Protocol::choose(options) {
+            Protocol::Kitty => kitty::preview(stdout, image_path, options)?,
+            Protocol::Iterm => iterm::preview(stdout, image_path, options)?,
+            Protocol::Sixel => sixel::preview(stdout, image_path, options)?,
+            Protocol::Blocks => blocks::preview(stdout, image_path, options)?,
+        }
     }
+    Ok(())
 }

--- a/src/previewer/mod.rs
+++ b/src/previewer/mod.rs
@@ -11,6 +11,10 @@ mod sixel;
 pub fn preview(stdout: &mut impl Write, options: &Options) -> Result {
     let protocol = Protocol::choose(options);
     for image_path in &options.path {
+        if image_path.is_dir() {
+            continue;
+        }
+
         match protocol {
             Protocol::Kitty => kitty::preview(stdout, image_path, options)?,
             Protocol::Iterm => iterm::preview(stdout, image_path, options)?,

--- a/src/previewer/mod.rs
+++ b/src/previewer/mod.rs
@@ -9,8 +9,9 @@ mod kitty;
 mod sixel;
 
 pub fn preview(stdout: &mut impl Write, options: &Options) -> Result {
+    let protocol = Protocol::choose(options);
     for image_path in &options.path {
-        match Protocol::choose(options) {
+        match protocol {
             Protocol::Kitty => kitty::preview(stdout, image_path, options)?,
             Protocol::Iterm => iterm::preview(stdout, image_path, options)?,
             Protocol::Sixel => sixel::preview(stdout, image_path, options)?,

--- a/src/previewer/sixel.rs
+++ b/src/previewer/sixel.rs
@@ -1,6 +1,6 @@
 use crate::options::Options;
 use crate::result::Result;
-use crate::utils::{fit_in_bounds, move_cursor, TermSize};
+use crate::utils::{fit_in_bounds, handle_spacing, move_cursor, TermSize};
 use sixel_rs::encoder::Encoder;
 use sixel_rs::optflags::{EncodePolicy, ResampleMethod, SizeSpecification::Pixel};
 use std::io::Write;
@@ -28,11 +28,13 @@ pub fn display(stdout: &mut impl Write, image_path: &PathBuf, options: &Options)
 
     move_cursor(stdout, options.x, options.y)?;
     encoder.encode_file(image_path)?;
-
     stdout.flush()?;
+
     Ok(())
 }
 
 pub fn preview(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> Result {
-    display(stdout, image_path, options)
+    display(stdout, image_path, options)?;
+    handle_spacing(stdout, options.spacing)?;
+    Ok(())
 }

--- a/src/previewer/sixel.rs
+++ b/src/previewer/sixel.rs
@@ -4,9 +4,10 @@ use crate::utils::{fit_in_bounds, move_cursor, TermSize};
 use sixel_rs::encoder::Encoder;
 use sixel_rs::optflags::{EncodePolicy, ResampleMethod, SizeSpecification::Pixel};
 use std::io::Write;
+use std::path::PathBuf;
 
-pub fn display(stdout: &mut impl Write, options: &Options) -> Result {
-    let image_size = imagesize::size(&options.path)?;
+pub fn display(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> Result {
+    let image_size = imagesize::size(image_path)?;
     let (width, height) = (image_size.width as u32, image_size.height as u32);
     let (cols, rows) = fit_in_bounds(width, height, options.cols, options.rows, options.upscale)?;
 
@@ -26,12 +27,12 @@ pub fn display(stdout: &mut impl Write, options: &Options) -> Result {
     };
 
     move_cursor(stdout, options.x, options.y)?;
-    encoder.encode_file(&options.path)?;
+    encoder.encode_file(image_path)?;
 
     stdout.flush()?;
     Ok(())
 }
 
-pub fn preview(stdout: &mut impl Write, options: &Options) -> Result {
-    display(stdout, options)
+pub fn preview(stdout: &mut impl Write, image_path: &PathBuf, options: &Options) -> Result {
+    display(stdout, image_path, options)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -93,7 +93,8 @@ impl TermSize {
 pub fn create_temp_file(prefix: &str) -> Result<(File, PathBuf)> {
     let (tempfile, pathbuf) = tempfile::Builder::new()
         .prefix(prefix)
-        .tempfile_in("/tmp/")?
+        .rand_bytes(1)
+        .tempfile()?
         .keep()?;
 
     Ok((tempfile, pathbuf))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -177,6 +177,14 @@ pub fn hide_cursor(stdout: &mut impl Write) -> Result {
     Ok(())
 }
 
+pub fn handle_spacing(stdout: &mut impl Write, spacing: Option<u32>) -> Result {
+    if let Some(spacing) = spacing {
+        stdout.write_all(&b"\n".repeat(spacing as usize))?;
+        stdout.flush()?;
+    }
+    Ok(())
+}
+
 pub fn fit_in_bounds(
     width: u32,
     height: u32,


### PR DESCRIPTION
# Feature
Allow the use of [wildcards](https://en.wikipedia.org/wiki/Wildcard_character#Computing) to display more than one image.

## Examples
```bash
pic -p iterm ~/Pictures/*.jpg
```
to display all `.jpg` images inside the `Pictures` directory.

```bash
pic ./*/*.png
```
to display all `.png` images inside any directory with depth 1 relative to pwd.

## TODO
- [ ] Display all image files if a directory is selected in path (Probably another PR)
- [ ] Allow grid display of images (Another PR, big changes)